### PR TITLE
Update ci-krkrsdl2.yml for supprting Apple Silicon

### DIFF
--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -233,7 +233,7 @@
       ]
     },
     "build-macos-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "steps" : [
         {
@@ -249,7 +249,7 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build"
+          "run" : "cmake -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' -S . -B build"
         },
         {
           "name" : "Build project",
@@ -282,7 +282,7 @@
       "steps" : [
         {
           "name" : "Download all artifacts",
-          "uses" : "actions/download-artifact@v3"
+          "uses" : "actions/download-artifact@master"
         },
         {
           "name" : "Prepare artifacts for release",


### PR DESCRIPTION
Changed for running on Apple Silicon without Rosetta 2.
I have confirmed that it works on image tag on an M1 Macbook Air and is a universal binary.

<img width="607" alt="image" src="https://github.com/krkrsdl2/krglhwebp/assets/58556570/b993a4cf-ce7b-48af-b36c-a0cbcc6dda99">
<img width="540" alt="image" src="https://github.com/krkrsdl2/krglhwebp/assets/58556570/5c80978a-96fa-4ad1-9b1c-277fab4ad1ce">
<img width="574" alt="image" src="https://github.com/krkrsdl2/krglhwebp/assets/58556570/d60fa9ab-98b6-42b6-8baa-fab559ea9468">
